### PR TITLE
Ability to append additional file extensions from setup()

### DIFF
--- a/lua/sops.lua
+++ b/lua/sops.lua
@@ -3,12 +3,15 @@ local util = require("util")
 ---@class SopsModule
 local M = {}
 
-local SUPPORTED_FILE_FORMATS = {
+local DEFAULT_SUPPORTED_FILE_FORMATS = {
   "*.yaml",
+  "*.yml",
   "*.json",
-  -- Assumes the `filetype` is set to `json`
   "*.dockerconfigjson",
 }
+
+---@type table
+local SUPPORTED_FILE_FORMATS = vim.deepcopy(DEFAULT_SUPPORTED_FILE_FORMATS)
 
 ---@param bufnr number
 local function sops_decrypt_buffer(bufnr)
@@ -23,17 +26,12 @@ local function sops_decrypt_buffer(bufnr)
     function(out)
       if out.code ~= 0 then
         vim.notify("Failed to decrypt file", vim.log.levels.WARN)
-
         return
       end
 
       vim.schedule(function()
         local decrypted_lines = vim.fn.split(out.stdout, "\n", false)
-
-        -- Make this buffer writable only through our auto command
         vim.api.nvim_set_option_value("buftype", "acwrite", { buf = bufnr })
-
-        -- Swap the buffer contents with the decrypted contents
         vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, decrypted_lines)
 
         -- Clear the undo history
@@ -42,13 +40,8 @@ local function sops_decrypt_buffer(bufnr)
         vim.cmd('exe "normal a \\<BS>\\<Esc>"')
         vim.api.nvim_set_option_value("undolevels", old_undo_levels, { buf = bufnr })
 
-        -- Mark the file as not modified
         vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
-
-        -- Run BufReadPost autocmds since the buffer contents have changed
-        vim.api.nvim_exec_autocmds("BufReadPost", {
-          buffer = bufnr,
-        })
+        vim.api.nvim_exec_autocmds("BufReadPost", { buffer = bufnr })
       end)
     end
   )
@@ -61,8 +54,6 @@ local function sops_encrypt_buffer(bufnr)
 
   local filetype = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
 
-  -- We have to use vim.fn.jobstart here because vim.system, and vim.uv don't support /dev/stdin
-  -- https://github.com/neovim/neovim/issues/14049
   local channel = vim.fn.jobstart({
     "sops",
     "--filename-override",
@@ -82,38 +73,37 @@ local function sops_encrypt_buffer(bufnr)
 
   if channel <= 0 then
     vim.notify("Failed to start job", vim.log.levels.WARN)
-
     return
   end
 
   local plaintext_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   vim.fn.chansend(channel, plaintext_lines)
-  -- Signal end of input. vim.fn.chanclose didn't seem to do the trick.
   vim.fn.chansend(channel, "\r\004")
 
   local code = vim.fn.jobwait({ channel }, 1000)[1]
   if code < 0 then
     vim.notify("Failed to run job", vim.log.levels.WARN)
-
     return
   end
 
   if code ~= 0 then
     vim.notify("SOPs failed to encrypt file: errno " .. code, vim.log.levels.WARN)
-
     return
   end
 
-  -- Mark the file as not modified
   vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
-
-  -- Run BufReadPost autocmds since the buffer contents have changed
-  vim.api.nvim_exec_autocmds("BufReadPost", {
-    buffer = bufnr,
-  })
+  vim.api.nvim_exec_autocmds("BufReadPost", { buffer = bufnr })
 end
 
-M.setup = function()
+M.setup = function(opts)
+  opts = opts or {}
+  if opts.supported_file_formats then
+    for _, format in ipairs(opts.supported_file_formats) do
+      table.insert(SUPPORTED_FILE_FORMATS, format)
+    end
+    vim.notify("SOPS.nvim configuration updated with additional patterns.", vim.log.levels.INFO)
+  end
+
   vim.api.nvim_create_autocmd({ "BufReadPost", "FileReadPost" }, {
     pattern = SUPPORTED_FILE_FORMATS,
     callback = function()
@@ -128,11 +118,7 @@ M.setup = function()
         buffer = bufnr,
         group = au_group,
         callback = function()
-          -- Clean up our autocmds
-          vim.api.nvim_clear_autocmds({
-            buffer = bufnr,
-            group = au_group,
-          })
+          vim.api.nvim_clear_autocmds({ buffer = bufnr, group = au_group })
         end,
       })
 
@@ -140,14 +126,10 @@ M.setup = function()
         buffer = bufnr,
         group = au_group,
         callback = function()
-          -- Saving the file will always result in the SOPS-encrypted file changing, so there's no reason to save the
-          -- file if the decrypted contents have not changed. Saves on false positive changes.
           if not vim.api.nvim_get_option_value("modified", { buf = bufnr }) then
             vim.notify("Skipping sops encryption. File has not been modified", vim.log.levels.INFO)
-
             return
           end
-
           sops_encrypt_buffer(bufnr)
         end,
       })

--- a/lua/sops.lua
+++ b/lua/sops.lua
@@ -3,10 +3,11 @@ local util = require("util")
 ---@class SopsModule
 local M = {}
 
+-- Default file formats supported by the plugin
 local DEFAULT_SUPPORTED_FILE_FORMATS = {
   "*.yaml",
-  "*.yml",
   "*.json",
+  -- Assumes the `filetype` is set to `json`
   "*.dockerconfigjson",
 }
 
@@ -26,12 +27,17 @@ local function sops_decrypt_buffer(bufnr)
     function(out)
       if out.code ~= 0 then
         vim.notify("Failed to decrypt file", vim.log.levels.WARN)
+
         return
       end
 
       vim.schedule(function()
         local decrypted_lines = vim.fn.split(out.stdout, "\n", false)
+
+        -- Make this buffer writable only through our auto command
         vim.api.nvim_set_option_value("buftype", "acwrite", { buf = bufnr })
+
+        -- Swap the buffer contents with the decrypted contents
         vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, decrypted_lines)
 
         -- Clear the undo history
@@ -40,8 +46,13 @@ local function sops_decrypt_buffer(bufnr)
         vim.cmd('exe "normal a \\<BS>\\<Esc>"')
         vim.api.nvim_set_option_value("undolevels", old_undo_levels, { buf = bufnr })
 
+        -- Mark the file as not modified
         vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
-        vim.api.nvim_exec_autocmds("BufReadPost", { buffer = bufnr })
+
+        -- Run BufReadPost autocmds since the buffer contents have changed
+        vim.api.nvim_exec_autocmds("BufReadPost", {
+          buffer = bufnr,
+        })
       end)
     end
   )
@@ -54,6 +65,8 @@ local function sops_encrypt_buffer(bufnr)
 
   local filetype = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
 
+  -- We have to use vim.fn.jobstart here because vim.system, and vim.uv don't support /dev/stdin
+  -- https://github.com/neovim/neovim/issues/14049
   local channel = vim.fn.jobstart({
     "sops",
     "--filename-override",
@@ -73,30 +86,42 @@ local function sops_encrypt_buffer(bufnr)
 
   if channel <= 0 then
     vim.notify("Failed to start job", vim.log.levels.WARN)
+
     return
   end
 
   local plaintext_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   vim.fn.chansend(channel, plaintext_lines)
+  -- Signal end of input. vim.fn.chanclose didn't seem to do the trick.
   vim.fn.chansend(channel, "\r\004")
 
   local code = vim.fn.jobwait({ channel }, 1000)[1]
   if code < 0 then
     vim.notify("Failed to run job", vim.log.levels.WARN)
+
     return
   end
 
   if code ~= 0 then
     vim.notify("SOPs failed to encrypt file: errno " .. code, vim.log.levels.WARN)
+
     return
   end
 
+  -- Mark the file as not modified
   vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
-  vim.api.nvim_exec_autocmds("BufReadPost", { buffer = bufnr })
+
+  -- Run BufReadPost autocmds since the buffer contents have changed
+  vim.api.nvim_exec_autocmds("BufReadPost", {
+    buffer = bufnr,
+  })
 end
 
+---@param opts table
 M.setup = function(opts)
   opts = opts or {}
+
+  -- Allow overriding or appending to the supported file formats
   if opts.supported_file_formats then
     for _, format in ipairs(opts.supported_file_formats) do
       table.insert(SUPPORTED_FILE_FORMATS, format)
@@ -118,7 +143,11 @@ M.setup = function(opts)
         buffer = bufnr,
         group = au_group,
         callback = function()
-          vim.api.nvim_clear_autocmds({ buffer = bufnr, group = au_group })
+          -- Clean up our autocmds
+          vim.api.nvim_clear_autocmds({
+            buffer = bufnr,
+            group = au_group,
+          })
         end,
       })
 
@@ -126,10 +155,14 @@ M.setup = function(opts)
         buffer = bufnr,
         group = au_group,
         callback = function()
+          -- Saving the file will always result in the SOPS-encrypted file changing, so there's no reason to save the
+          -- file if the decrypted contents have not changed. Saves on false positive changes.
           if not vim.api.nvim_get_option_value("modified", { buf = bufnr }) then
             vim.notify("Skipping sops encryption. File has not been modified", vim.log.levels.INFO)
+
             return
           end
+
           sops_encrypt_buffer(bufnr)
         end,
       })


### PR DESCRIPTION
A simple fix to allow users to specify additional filetypes like *.yml.

Config file format:
```
return {
  "trixnz/sops.nvim",
  config = function()
    require("sops").setup({
      additional_file_formats = {
        "*.enc.yaml",
        "*.enc.yml",
        "*.enc.json",
        "*.yml", -- Add generic yml support
      },
    })
  end,
}
```